### PR TITLE
Fix visibility setting by replacing $config->has() with $config->get()

### DIFF
--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -139,8 +139,8 @@ class GoogleStorageAdapter extends AbstractAdapter
     {
         $options = [];
 
-        if ($config->has('visibility')) {
-            $options['predefinedAcl'] = $this->getPredefinedAclForVisibility($config->get('visibility'));
+        if ($visibility = $config->get('visibility')) {
+            $options['predefinedAcl'] = $this->getPredefinedAclForVisibility($visibility);
         } else {
             // if a file is created without an acl, it isn't accessible via the console
             // we therefore default to private


### PR DESCRIPTION
Currently `League\Flysystem\Config::has()` doesn't check if the `$key` exists on the fallback config. 

I was testing this adapter and it [relies on the previously mentioned method](https://github.com/Superbalist/flysystem-google-cloud-storage/blob/master/src/GoogleStorageAdapter.php#L142) to check if the `visibility` was set but it would never return true, so after some debugging this is my finding and suggested fix.

I've opened [this pull request](https://github.com/thephpleague/flysystem/pull/705) on [thephpleague/flysystem](https://github.com/thephpleague/flysystem) to fix the issue on their side, but for now we could implement this permanent fix.

FYI apparently thePHPleague uses the `get` method on their adapters to get the `visibility`:
- [thephpleague/flysystem-aws-s3-v3](https://github.com/thephpleague/flysystem-aws-s3-v3/blob/master/src/AwsS3Adapter.php#L595)
- [thephpleague/flysystem-sftp](https://github.com/thephpleague/flysystem-sftp/blob/master/src/SftpAdapter.php#L360)
- [thephpleague/flysystem-ziparchive](https://github.com/thephpleague/flysystem-ziparchive/blob/master/src/ZipArchiveAdapter.php#L108)