### PR TITLE
readStream now returns a resource instead of a `StreamInterface`

### DIFF
--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -7,6 +7,7 @@ use Google\Cloud\Storage\Acl;
 use Google\Cloud\Storage\Bucket;
 use Google\Cloud\Storage\StorageClient;
 use Google\Cloud\Storage\StorageObject;
+use GuzzleHttp\Psr7\StreamWrapper;
 use League\Flysystem\Adapter\AbstractAdapter;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\Config;
@@ -319,7 +320,7 @@ class GoogleStorageAdapter extends AbstractAdapter
         $object = $this->getObject($path);
 
         $data = $this->normaliseObject($object);
-        $data['stream'] = $object->downloadAsStream();
+        $data['stream'] = StreamWrapper::getResource($object->downloadAsStream());
 
         return $data;
     }

--- a/tests/GoogleStorageAdapterTests.php
+++ b/tests/GoogleStorageAdapterTests.php
@@ -521,6 +521,12 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $bucket = Mockery::mock(Bucket::class);
 
         $stream = Mockery::mock(StreamInterface::class);
+        $stream->shouldReceive('isReadable')
+            ->once()
+            ->andReturn(true);
+        $stream->shouldReceive('isWritable')
+            ->once()
+            ->andReturn(false);
 
         $storageObject = Mockery::mock(StorageObject::class);
         $storageObject->shouldReceive('downloadAsStream')
@@ -547,7 +553,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $data = $adapter->readStream('file.txt');
 
         $this->assertArrayHasKey('stream', $data);
-        $this->assertInstanceOf(StreamInterface::class, $data['stream']);
+        $this->assertInternalType('resource', $data['stream']);
     }
 
     public function testListContents()


### PR DESCRIPTION
A possible fix for #53 