### PR TITLE
FIX: No bucket name prepending when using a custom URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,33 @@ $filesystem->deleteDir('path/to/directory');
 
 // see http://flysystem.thephpleague.com/api/ for full list of available functionality
 ```
+
+## Google Storage specifics
+
+When using a custom storage uri the bucket name will not prepended to the file path.
+
+```php
+$storageClient = new StorageClient([
+    'projectId' => 'your-project-id',
+]);
+$bucket = $storageClient->bucket('your-bucket-name');
+$adapter = new GoogleStorageAdapter($storageClient, $bucket);
+
+// uri defaults to "https://storage.googleapis.com"
+$filesystem = new Filesystem($adapter);
+$filesystem->getUrl('path/to/file.txt');
+// "https://storage.googleapis.com/your-bucket-name/path/to/file.txt"
+
+// set custom storage uri
+$adapter->setStorageApiUri('http://example.com');
+$filesystem = new Filesystem($adapter);
+$filesystem->getUrl('path/to/file.txt');
+// "http://example.com/path/to/file.txt"
+
+// You can also prefix the file path if needed.
+$adapter->setStorageApiUri('http://example.com');
+$adapter->setPathPrefix('extra-folder/another-folder/');
+$filesystem = new Filesystem($adapter);
+$filesystem->getUrl('path/to/file.txt');
+// "http://example.com/extra-folder/another-folder/path/to/file.txt"
+```

--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -16,6 +16,11 @@ use League\Flysystem\Util;
 class GoogleStorageAdapter extends AbstractAdapter
 {
     /**
+     * @const STORAGE_API_URI_DEFAULT
+     */
+    const STORAGE_API_URI_DEFAULT = 'https://storage.googleapis.com';
+
+    /**
      * @var StorageClient
      */
     protected $storageClient;
@@ -28,7 +33,7 @@ class GoogleStorageAdapter extends AbstractAdapter
     /**
      * @var string
      */
-    protected $storageApiUri = 'https://storage.googleapis.com';
+    protected $storageApiUri;
 
     /**
      * @param StorageClient $storageClient
@@ -45,9 +50,7 @@ class GoogleStorageAdapter extends AbstractAdapter
             $this->setPathPrefix($pathPrefix);
         }
 
-        if ($storageApiUri) {
-            $this->storageApiUri = $storageApiUri;
-        }
+        $this->storageApiUri = ($storageApiUri) ?: self::STORAGE_API_URI_DEFAULT;
     }
 
     /**
@@ -82,8 +85,6 @@ class GoogleStorageAdapter extends AbstractAdapter
 
     /**
      * Return the storage api uri.
-     *
-     * @param string $uri
      *
      * @return string
      */
@@ -398,7 +399,15 @@ class GoogleStorageAdapter extends AbstractAdapter
     {
         $uri = rtrim($this->storageApiUri, '/');
         $path = $this->applyPathPrefix($path);
-        return $uri . '/' . $this->bucket->name() . '/' . $path;
+
+        // Only prepend bucket name if no custom storage uri specified
+        // Default: "https://storage.googleapis.com/{my_bucket}/{path_prefix}"
+        // Custom: "https://example.com/{path_prefix}"
+        if ($this->getStorageApiUri() === self::STORAGE_API_URI_DEFAULT) {
+            $path = $this->bucket->name() . '/' . $path;
+        }
+
+        return $uri . '/' . $path;
     }
 
     /**

--- a/tests/GoogleStorageAdapterTests.php
+++ b/tests/GoogleStorageAdapterTests.php
@@ -918,6 +918,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
 
         $adapter->setStorageApiUri('http://my-domain.com/');
         $adapter->setPathPrefix('another-prefix');
-        $this->assertEquals('http://my-domain.com/my-bucket/another-prefix/dir/file.txt', $adapter->getUrl('dir/file.txt'));
+        // no bucket name on custom domain
+        $this->assertEquals('http://my-domain.com/another-prefix/dir/file.txt', $adapter->getUrl('dir/file.txt'));
     }
 }


### PR DESCRIPTION
Changes:

ff453cb
   update readme

7b8f2a2
   fix: remove bucket name prepending when using a custom storage uri