### PR TITLE
Add support for temporaryUrl

### DIFF
--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -411,6 +411,19 @@ class GoogleStorageAdapter extends AbstractAdapter
     }
 
     /**
+     * Returns temporary url
+     * 
+     * @param       $path
+     * @param       $expiration
+     * @param array $options
+     * @return string
+     */
+    public function getTemporaryUrl($path, $expiration, array $options = [])
+    {
+        return $this->getObject($path)->signedUrl($expiration, $options);
+    }
+    
+    /**
      * @param string $path
      *
      * @return string


### PR DESCRIPTION
This will allow you to create temporary urls via the Storage facade.

```
$url = Storage::temporaryUrl(
    'file1.jpg', now()->addMinutes(5)
);
```

This will use the `signedUrl` method on the `StorageObject` class:
https://github.com/GoogleCloudPlatform/google-cloud-php-storage/blob/master/src/StorageObject.php#L698

