### PR TITLE
Upgrade to latest google cloud storage php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	"require": {
 		"php": ">=5.5.0",
 		"league/flysystem": "~1.0",
-		"google/cloud-storage": ">=1.0 <1.4"
+		"google/cloud-storage": ">=1.7.2"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.0",


### PR DESCRIPTION
This gets us away from a versioning issue that Google introduced today.  **GoogleCloudPlatform/google-cloud-php-storage** versions less than v1.7.1 no longer work.  See https://github.com/GoogleCloudPlatform/google-cloud-php-core/commit/6f1b06cbf11f85d5c454eb98ead448e07af49fec