### PR TITLE
Catch NotFoundException on delete allUsers ACL, ignore.

### DIFF
--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -280,7 +280,12 @@ class GoogleStorageAdapter extends AbstractAdapter
         $object = $this->getObject($path);
 
         if ($visibility === AdapterInterface::VISIBILITY_PRIVATE) {
+          try {
             $object->acl()->delete('allUsers');
+          }
+          catch (NotFoundException $e) {
+            // Not actually an exception, no ACL to delete.
+          }
         } elseif ($visibility === AdapterInterface::VISIBILITY_PUBLIC) {
             $object->acl()->add('allUsers', Acl::ROLE_READER);
         }


### PR DESCRIPTION
If an object is uploaded with private visibility, and then later an application (in this case, Drupal) does a setVisibility operation on the object to private, a `NotFoundException` is thrown since there is no `allUsers` ACL to delete. This patch catches that specific exception (but would allow others to bubble up), as it's not truly a failure case.