### PR TITLE
bugfix: generate rfc 3986 compliant urls

### DIFF
--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -400,6 +400,11 @@ class GoogleStorageAdapter extends AbstractAdapter
         $uri = rtrim($this->storageApiUri, '/');
         $path = $this->applyPathPrefix($path);
 
+        // Generating an uri with whitespaces or any other characters besides alphanumeric characters or "-_.~" will
+        // not be RFC 3986 compliant. They will work in most browsers because they are automatically encoded but
+        // may fail when passed to other software modules which are not doing automatic encoding.
+        $path = implode('/', array_map('rawurlencode', explode('/', $path)));
+
         // Only prepend bucket name if no custom storage uri specified
         // Default: "https://storage.googleapis.com/{my_bucket}/{path_prefix}"
         // Custom: "https://example.com/{path_prefix}"

--- a/tests/GoogleStorageAdapterTests.php
+++ b/tests/GoogleStorageAdapterTests.php
@@ -912,6 +912,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
 
         $adapter = new GoogleStorageAdapter($storageClient, $bucket);
         $this->assertEquals('https://storage.googleapis.com/my-bucket/file.txt', $adapter->getUrl('file.txt'));
+        $this->assertEquals('https://storage.googleapis.com/my-bucket/test%20folder/file%281%29.txt', $adapter->getUrl('test folder/file(1).txt'));
 
         $adapter->setPathPrefix('prefix');
         $this->assertEquals('https://storage.googleapis.com/my-bucket/prefix/file.txt', $adapter->getUrl('file.txt'));


### PR DESCRIPTION
Generating an uri with whitespaces or any other characters besides alphanumeric characters or "-_.~" will not be RFC 3986 compliant. They will work in most browsers because they are automatically encoded but may fail when passed to other software modules which are not doing automatic encoding.

This pull request will change url generation slightly that they are still pointing to the same destination but all url special characters are encoded for software that does not do the encoding by itself.