### PR TITLE
On branch bugfix/deleteDirFails

### DIFF
--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -254,13 +254,18 @@ class GoogleStorageAdapter extends AbstractAdapter
 
         // We first delete the file, so that we can delete
         // the empty folder at the end.
-        uasort($objects, function ($a, $b) {
+        uasort($objects, function ($b) {
             return $b['type'] === 'file' ? 1 : -1;
         });
 
         // We remove all objects that should not be deleted.
         $filtered_objects = [];
         foreach ($objects as $object) {
+            // normalise directories path
+            if ($object['type'] === 'dir') {
+                $object['path'] = $this->normaliseDirName($object['path']);
+            }
+
             if (strpos($object['path'], $dirname) !== false) {
                 $filtered_objects[] = $object;
             }
@@ -268,13 +273,7 @@ class GoogleStorageAdapter extends AbstractAdapter
 
         // Execute deletion for each object.
         foreach ($filtered_objects as $object) {
-            $path = $object['path'];
-
-            if ($object['type'] === 'dir') {
-                $path = $this->normaliseDirName($path);
-            }
-
-            $this->delete($path);
+            $this->delete($object['path']);
         }
 
         return true;

--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -254,7 +254,7 @@ class GoogleStorageAdapter extends AbstractAdapter
 
         // We first delete the file, so that we can delete
         // the empty folder at the end.
-        uasort($objects, function ($b) {
+        uasort($objects, function ($a, $b) {
             return $b['type'] === 'file' ? 1 : -1;
         });
 

--- a/tests/GoogleStorageAdapterTests.php
+++ b/tests/GoogleStorageAdapterTests.php
@@ -353,7 +353,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
 
         $storageObject = Mockery::mock(StorageObject::class);
         $storageObject->shouldReceive('delete')
-            ->twice();
+            ->times(3);
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/dir_name/directory1/file1.txt');
@@ -372,6 +372,11 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
 
         $bucket->shouldReceive('object')
             ->with('prefix/dir_name/directory1/')
+            ->once()
+            ->andReturn($storageObject);
+
+        $bucket->shouldReceive('object')
+            ->with('prefix/dir_name/')
             ->once()
             ->andReturn($storageObject);
 
@@ -393,7 +398,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
 
         $storageObject = Mockery::mock(StorageObject::class);
         $storageObject->shouldReceive('delete')
-            ->twice();
+            ->times(3);
 
         $storageObject->shouldReceive('name')
             ->once()
@@ -413,6 +418,11 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
 
         $bucket->shouldReceive('object')
             ->with('prefix/dir_name/directory1/')
+            ->once()
+            ->andReturn($storageObject);
+
+        $bucket->shouldReceive('object')
+            ->with('prefix/dir_name/')
             ->once()
             ->andReturn($storageObject);
 


### PR DESCRIPTION
Changes to be committed:
	modified:   src/GoogleStorageAdapter.php
	modified:   tests/GoogleStorageAdapterTests.php
Issue: deleteDir method was deleting all the content including directories inside the directory  but not the directory.

Reason: While adding contetnt to filterObject array the dirname was normalized but the name received from the listContent was not

Solution: Normalized all directories path before adding them to filtered_objects array
Update test to covner the updated code