### PR TITLE
fix ResumableUploader.php error

### DIFF
--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -152,6 +152,13 @@ class GoogleStorageAdapter extends AbstractAdapter
             $options['metadata'] = $metadata;
         }
 
+        if ($chunkSize = $config->get('chunkSize')) {
+            $options['chunkSize'] = $chunkSize;
+        }
+        if ($uploadProgressCallback = $config->get('uploadProgressCallback')) {
+            $options['uploadProgressCallback'] = $uploadProgressCallback;
+        }
+
         return $options;
     }
 


### PR DESCRIPTION
for the error ResumableUploader.php line 179: Upload failed. Please use this URI to resume your upload

use:
```$disk->put($targetNamePath, fopen(Storage::path($localTmp_targetNamePath), 'r+'), [
                'resumable' => true,
                'chunkSize' => 262144 * 50,
                'uploadProgressCallback' => array($this, 'uploadProgress'),
            ]);```