### PR TITLE
Fix Delete directory method failing when directory did not exist anymore

### DIFF
--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -273,7 +273,9 @@ class GoogleStorageAdapter extends AbstractAdapter
 
         // Execute deletion for each object.
         foreach ($filtered_objects as $object) {
-            $this->delete($object['path']);
+            if ($this->has($object['path'])) {
+                $this->delete($object['path']);
+            }
         }
 
         return true;

--- a/tests/GoogleStorageAdapterTests.php
+++ b/tests/GoogleStorageAdapterTests.php
@@ -352,6 +352,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $bucket = Mockery::mock(Bucket::class);
 
         $storageObject = Mockery::mock(StorageObject::class);
+        $storageObject->shouldReceive('exists')->times(3)->andReturn(true);
         $storageObject->shouldReceive('delete')
             ->times(3);
         $storageObject->shouldReceive('name')
@@ -367,17 +368,17 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
 
         $bucket->shouldReceive('object')
             ->with('prefix/dir_name/directory1/file1.txt')
-            ->once()
+            ->times(2)
             ->andReturn($storageObject);
 
         $bucket->shouldReceive('object')
             ->with('prefix/dir_name/directory1/')
-            ->once()
+            ->times(2)
             ->andReturn($storageObject);
 
         $bucket->shouldReceive('object')
             ->with('prefix/dir_name/')
-            ->once()
+            ->times(2)
             ->andReturn($storageObject);
 
         $bucket->shouldReceive('objects')
@@ -397,6 +398,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $bucket = Mockery::mock(Bucket::class);
 
         $storageObject = Mockery::mock(StorageObject::class);
+        $storageObject->shouldReceive('exists')->times(3)->andReturn(true);
         $storageObject->shouldReceive('delete')
             ->times(3);
 
@@ -413,17 +415,17 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
 
         $bucket->shouldReceive('object')
             ->with('prefix/dir_name/directory1/file1.txt')
-            ->once()
+            ->times(2)
             ->andReturn($storageObject);
 
         $bucket->shouldReceive('object')
             ->with('prefix/dir_name/directory1/')
-            ->once()
+            ->times(2)
             ->andReturn($storageObject);
 
         $bucket->shouldReceive('object')
             ->with('prefix/dir_name/')
-            ->once()
+            ->times(2)
             ->andReturn($storageObject);
 
         $bucket->shouldReceive('objects')


### PR DESCRIPTION
Noticed a small issue, not really sure why to be honest, probably a setting on GCS, but unsure where to unset it, but whenever i deleted a directory, it deleted the files totally fine although when it was trying to delete the directory it would fail because the directory was already deleted 🤷‍♂ 