### PR TITLE
Allow uniform access rules on upload

### DIFF
--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -139,7 +139,7 @@ class GoogleStorageAdapter extends AbstractAdapter
     protected function getOptionsFromConfig(Config $config)
     {
         $options = [];
-        if (!($this->bucket->info()['iamConfiguration']['uniformBucketLevelAccess']['enabled'] ?? false)) {
+        if (empty($this->bucket->info()['iamConfiguration']['uniformBucketLevelAccess']['enabled']) {
             if ($visibility = $config->get('visibility')) {
                 $options['predefinedAcl'] = $this->getPredefinedAclForVisibility($visibility);
             } else {

--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -139,13 +139,14 @@ class GoogleStorageAdapter extends AbstractAdapter
     protected function getOptionsFromConfig(Config $config)
     {
         $options = [];
-
-        if ($visibility = $config->get('visibility')) {
-            $options['predefinedAcl'] = $this->getPredefinedAclForVisibility($visibility);
-        } else {
-            // if a file is created without an acl, it isn't accessible via the console
-            // we therefore default to private
-            $options['predefinedAcl'] = $this->getPredefinedAclForVisibility(AdapterInterface::VISIBILITY_PRIVATE);
+        if (!($this->bucket->info()['iamConfiguration']['uniformBucketLevelAccess']['enabled'] ?? false)) {
+            if ($visibility = $config->get('visibility')) {
+                $options['predefinedAcl'] = $this->getPredefinedAclForVisibility($visibility);
+            } else {
+                // if a file is created without an acl, it isn't accessible via the console
+                // we therefore default to private
+                $options['predefinedAcl'] = $this->getPredefinedAclForVisibility(AdapterInterface::VISIBILITY_PRIVATE);
+            }
         }
 
         if ($metadata = $config->get('metadata')) {

--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -139,7 +139,7 @@ class GoogleStorageAdapter extends AbstractAdapter
     protected function getOptionsFromConfig(Config $config)
     {
         $options = [];
-        if (empty($this->bucket->info()['iamConfiguration']['uniformBucketLevelAccess']['enabled']) {
+        if (empty($this->bucket->info()['iamConfiguration']['uniformBucketLevelAccess']['enabled'])) {
             if ($visibility = $config->get('visibility')) {
                 $options['predefinedAcl'] = $this->getPredefinedAclForVisibility($visibility);
             } else {


### PR DESCRIPTION
Currently the code forces an ACL on the files, this doesn't work if the bucket has uniform access policies set. So this PR just checks whether the bucket has uniform access before setting the ACL.