### PR TITLE
Improved mimetype fallback (equal to AWS driver)

### DIFF
--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -167,9 +167,15 @@ class GoogleStorageAdapter extends AbstractAdapter
     protected function upload($path, $contents, Config $config)
     {
         $path = $this->applyPathPrefix($path);
-
         $options = $this->getOptionsFromConfig($config);
+
         $options['name'] = $path;
+
+        if ( ! $this->isOnlyDir($path)) {
+            if ( ! isset($options['metadata']['contentType'])) {
+                $options['metadata']['contentType'] = Util::guessMimeType($path, $contents);
+            }
+        }
 
         $object = $this->bucket->upload($contents, $options);
 
@@ -188,7 +194,7 @@ class GoogleStorageAdapter extends AbstractAdapter
         $name = $this->removePathPrefix($object->name());
         $info = $object->info();
 
-        $isDir = substr($name, -1) === '/';
+        $isDir = $this->isOnlyDir($name);
         if ($isDir) {
             $name = rtrim($name, '/');
         }
@@ -536,5 +542,17 @@ class GoogleStorageAdapter extends AbstractAdapter
     protected function getPredefinedAclForVisibility($visibility)
     {
         return $visibility === AdapterInterface::VISIBILITY_PUBLIC ? 'publicRead' : 'projectPrivate';
+    }
+
+    /**
+     * Check if the path contains only directories
+     *
+     * @param string $path
+     *
+     * @return bool
+     */
+    protected function isOnlyDir($path)
+    {
+        return substr($path, -1) === '/';
     }
 }

--- a/tests/GoogleStorageAdapterTests.php
+++ b/tests/GoogleStorageAdapterTests.php
@@ -54,6 +54,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 [
                     'name' => 'prefix/file1.txt',
                     'predefinedAcl' => 'projectPrivate',
+                    'metadata' => ['contentType' => 'text/plain']
                 ],
             ])
             ->once()
@@ -98,6 +99,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 [
                     'name' => 'prefix/file1.txt',
                     'predefinedAcl' => 'projectPrivate',
+                    'metadata' => ['contentType' => 'text/plain']
                 ],
             ])
             ->once()
@@ -142,6 +144,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 [
                     'name' => 'prefix/file1.txt',
                     'predefinedAcl' => 'publicRead',
+                    'metadata' => ['contentType' => 'text/plain']
                 ],
             ])
             ->once()
@@ -188,6 +191,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 [
                     'name' => 'prefix/file1.txt',
                     'predefinedAcl' => 'projectPrivate',
+                    'metadata' => ['contentType' => 'text/plain']
                 ],
             ])
             ->once()


### PR DESCRIPTION
This PR aligns this driver with the functionality of the AWS driver regarding it's mimetype detection. The GCS-lib has a mimetype detection, but it bases only on the file extension.

Meanwhile, Flysystems brings it's own mimetype detection, detecting the mimetype from the contents and as fallback from the file extension.

Check the equal in [AwsS3Adapter](https://github.com/thephpleague/flysystem-aws-s3-v3/blob/master/src/AwsS3Adapter.php#L595)