### PR TITLE
Add mimetype option compatibility (equal to AWS driver)

### DIFF
--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -148,6 +148,13 @@ class GoogleStorageAdapter extends AbstractAdapter
             $options['predefinedAcl'] = $this->getPredefinedAclForVisibility(AdapterInterface::VISIBILITY_PRIVATE);
         }
 
+        if ($mimetype = $config->get('mimetype')) {
+            // For local reference
+            $options['mimetype'] = $mimetype;
+            // For external reference
+            $options['metadata']['contentType'] = $mimetype;
+        }
+
         if ($metadata = $config->get('metadata')) {
             $options['metadata'] = $metadata;
         }


### PR DESCRIPTION
This PR aligns this driver with the functionality of the AWS driver regarding how the mimetype can be manually set.

The AwsS3Adapter tries to `mimetype` from config and overrules the mimetype-detection, if it's present.

Check the equal in [AwsS3Adapter](https://github.com/thephpleague/flysystem-aws-s3-v3/blob/master/src/AwsS3Adapter.php#L647).