### PR TITLE
Uniform access rules on upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 5.6
   - 7.1
   - 7.2
-  - 7.3
 
 env:
   - GOOGLE_CLOUD_STORAGE="1.0.*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.6
   - 7.1
   - 7.2
+  - 7.3
 
 env:
   - GOOGLE_CLOUD_STORAGE="1.0.*"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"google/cloud-storage": "~1.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "~4.0",
+		"phpunit/phpunit": "~5.0",
 		"mockery/mockery": "0.9.*"
 	},
 	"autoload": {

--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -140,6 +140,7 @@ class GoogleStorageAdapter extends AbstractAdapter
     {
         $options = [];
 
+
         if (empty($this->bucket->info()['iamConfiguration']['uniformBucketLevelAccess']['enabled'])) {
             if ($visibility = $config->get('visibility')) {
                 $options['predefinedAcl'] = $this->getPredefinedAclForVisibility($visibility);

--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -140,7 +140,6 @@ class GoogleStorageAdapter extends AbstractAdapter
     {
         $options = [];
 
-
         if (empty($this->bucket->info()['iamConfiguration']['uniformBucketLevelAccess']['enabled'])) {
             if ($visibility = $config->get('visibility')) {
                 $options['predefinedAcl'] = $this->getPredefinedAclForVisibility($visibility);

--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -140,12 +140,14 @@ class GoogleStorageAdapter extends AbstractAdapter
     {
         $options = [];
 
-        if ($visibility = $config->get('visibility')) {
-            $options['predefinedAcl'] = $this->getPredefinedAclForVisibility($visibility);
-        } else {
-            // if a file is created without an acl, it isn't accessible via the console
-            // we therefore default to private
-            $options['predefinedAcl'] = $this->getPredefinedAclForVisibility(AdapterInterface::VISIBILITY_PRIVATE);
+        if (empty($this->bucket->info()['iamConfiguration']['uniformBucketLevelAccess']['enabled'])) {
+            if ($visibility = $config->get('visibility')) {
+                $options['predefinedAcl'] = $this->getPredefinedAclForVisibility($visibility);
+            } else {
+                // if a file is created without an acl, it isn't accessible via the console
+                // we therefore default to private
+                $options['predefinedAcl'] = $this->getPredefinedAclForVisibility(AdapterInterface::VISIBILITY_PRIVATE);
+            }
         }
 
         if ($metadata = $config->get('metadata')) {

--- a/tests/GoogleStorageAdapterTests.php
+++ b/tests/GoogleStorageAdapterTests.php
@@ -40,8 +40,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file1.txt');
-
-        $bucket->shouldReceive('info')
+        $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -49,6 +48,11 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
+
+	    $bucket->shouldReceive('info')
+		    ->andReturn([
+			    'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]]
+		    ]);
         $bucket->shouldReceive('upload')
             ->withArgs([
                 'This is the file contents.',
@@ -85,15 +89,19 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file1.txt');
-
-        $bucket->shouldReceive('info')
+        $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
+
+	    $bucket->shouldReceive('info')
+		    ->andReturn([
+			    'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]]
+		    ]);
+
         $bucket->shouldReceive('upload')
             ->withArgs([
                 'This is the file contents.',
@@ -130,15 +138,18 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file1.txt');
-        $bucket->shouldReceive('info')
+        $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
 
+	    $bucket->shouldReceive('info')
+		    ->andReturn([
+			    'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]]
+		    ]);
         $bucket->shouldReceive('upload')
             ->withArgs([
                 'This is the file contents.',
@@ -177,15 +188,18 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file1.txt');
-        $bucket->shouldReceive('info')
+        $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
 
+	    $bucket->shouldReceive('info')
+		    ->andReturn([
+			    'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]]
+		    ]);
         $bucket->shouldReceive('upload')
             ->withArgs([
                 $stream,
@@ -361,15 +375,18 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/dir_name/directory1/file1.txt');
-
-        $bucket->shouldReceive('info')
+        $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
+
+	    $bucket->shouldReceive('info')
+		    ->andReturn([
+			    'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]]
+		    ]);
         $bucket->shouldReceive('object')
             ->with('prefix/dir_name/directory1/file1.txt')
             ->once()
@@ -408,15 +425,19 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/dir_name/directory1/file1.txt');
-
-        $bucket->shouldReceive('info')
+        $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
+
+	    $bucket->shouldReceive('info')
+		    ->andReturn([
+			    'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]]
+		    ]);
+
         $bucket->shouldReceive('object')
             ->with('prefix/dir_name/directory1/file1.txt')
             ->once()
@@ -459,15 +480,18 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-
-        $bucket->shouldReceive('info')
+        $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
+
+	    $bucket->shouldReceive('info')
+		    ->andReturn([
+			    'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]]
+		    ]);
         $bucket->shouldReceive('object')
             ->with('prefix/file1.txt')
             ->once()
@@ -501,15 +525,18 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-
-        $bucket->shouldReceive('info')
+        $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
+
+	    $bucket->shouldReceive('info')
+		    ->andReturn([
+			    'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]]
+		    ]);
         $bucket->shouldReceive('object')
             ->with('prefix/file1.txt')
             ->once()
@@ -555,15 +582,18 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-
-        $bucket->shouldReceive('info')
+        $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
+
+	    $bucket->shouldReceive('info')
+		    ->andReturn([
+			    'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]]
+		    ]);
         $bucket->shouldReceive('object')
             ->with('prefix/file.txt')
             ->once()
@@ -597,15 +627,18 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-
-        $bucket->shouldReceive('info')
+        $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
+
+	    $bucket->shouldReceive('info')
+		    ->andReturn([
+			    'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]]
+		    ]);
         $bucket->shouldReceive('object')
             ->with('prefix/file.txt')
             ->once()
@@ -733,15 +766,18 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-
-        $bucket->shouldReceive('info')
+        $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
+
+	    $bucket->shouldReceive('info')
+		    ->andReturn([
+			    'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]]
+		    ]);
         $bucket->shouldReceive('object')
             ->with('prefix/file.txt')
             ->once()
@@ -772,15 +808,18 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/directory/');
-
-        $bucket->shouldReceive('info')
+        $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'application/octet-stream',
                 'size' => 0,
             ]);
+
+	    $bucket->shouldReceive('info')
+		    ->andReturn([
+			    'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]]
+		    ]);
         $bucket->shouldReceive('object')
             ->with('prefix/directory')
             ->once()
@@ -811,16 +850,18 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-
-        $bucket->shouldReceive('info')
+        $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
 
+	    $bucket->shouldReceive('info')
+		    ->andReturn([
+			    'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]]
+		    ]);
         $bucket->shouldReceive('object')
             ->with('prefix/file.txt')
             ->once()
@@ -843,15 +884,18 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-
-        $bucket->shouldReceive('info')
+        $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
+
+	    $bucket->shouldReceive('info')
+		    ->andReturn([
+			    'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]]
+		    ]);
         $bucket->shouldReceive('object')
             ->with('prefix/file.txt')
             ->once()
@@ -874,15 +918,18 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-
-        $bucket->shouldReceive('info')
+        $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
+
+	    $bucket->shouldReceive('info')
+		    ->andReturn([
+			    'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]]
+		    ]);
         $bucket->shouldReceive('object')
             ->with('prefix/file.txt')
             ->once()

--- a/tests/GoogleStorageAdapterTests.php
+++ b/tests/GoogleStorageAdapterTests.php
@@ -40,7 +40,8 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file1.txt');
-        $storageObject->shouldReceive('info')
+
+        $bucket->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -48,7 +49,6 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
-
         $bucket->shouldReceive('upload')
             ->withArgs([
                 'This is the file contents.',
@@ -85,7 +85,8 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file1.txt');
-        $storageObject->shouldReceive('info')
+
+        $bucket->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -93,7 +94,6 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
-
         $bucket->shouldReceive('upload')
             ->withArgs([
                 'This is the file contents.',
@@ -130,7 +130,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file1.txt');
-        $storageObject->shouldReceive('info')
+        $bucket->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -177,7 +177,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file1.txt');
-        $storageObject->shouldReceive('info')
+        $bucket->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -361,7 +361,8 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/dir_name/directory1/file1.txt');
-        $storageObject->shouldReceive('info')
+
+        $bucket->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -369,7 +370,6 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
-
         $bucket->shouldReceive('object')
             ->with('prefix/dir_name/directory1/file1.txt')
             ->once()
@@ -408,7 +408,8 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/dir_name/directory1/file1.txt');
-        $storageObject->shouldReceive('info')
+
+        $bucket->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -416,7 +417,6 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
-
         $bucket->shouldReceive('object')
             ->with('prefix/dir_name/directory1/file1.txt')
             ->once()
@@ -459,7 +459,8 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-        $storageObject->shouldReceive('info')
+
+        $bucket->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -467,7 +468,6 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
-
         $bucket->shouldReceive('object')
             ->with('prefix/file1.txt')
             ->once()
@@ -501,7 +501,8 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-        $storageObject->shouldReceive('info')
+
+        $bucket->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -509,7 +510,6 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
-
         $bucket->shouldReceive('object')
             ->with('prefix/file1.txt')
             ->once()
@@ -555,7 +555,8 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-        $storageObject->shouldReceive('info')
+
+        $bucket->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -563,7 +564,6 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
-
         $bucket->shouldReceive('object')
             ->with('prefix/file.txt')
             ->once()
@@ -597,7 +597,8 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-        $storageObject->shouldReceive('info')
+
+        $bucket->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -605,7 +606,6 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
-
         $bucket->shouldReceive('object')
             ->with('prefix/file.txt')
             ->once()
@@ -688,7 +688,6 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $dir1->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'application/octet-stream',
                 'size' => 0,
@@ -701,7 +700,6 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $dir1file1->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -714,7 +712,6 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $dir2file1->shouldReceive('info')
             ->once()
             ->andReturn([
-                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -736,7 +733,8 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-        $storageObject->shouldReceive('info')
+
+        $bucket->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -744,7 +742,6 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
-
         $bucket->shouldReceive('object')
             ->with('prefix/file.txt')
             ->once()
@@ -775,7 +772,8 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/directory/');
-        $storageObject->shouldReceive('info')
+
+        $bucket->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -783,7 +781,6 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 'contentType' => 'application/octet-stream',
                 'size' => 0,
             ]);
-
         $bucket->shouldReceive('object')
             ->with('prefix/directory')
             ->once()
@@ -814,7 +811,8 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-        $storageObject->shouldReceive('info')
+
+        $bucket->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -845,7 +843,8 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-        $storageObject->shouldReceive('info')
+
+        $bucket->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -853,7 +852,6 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
-
         $bucket->shouldReceive('object')
             ->with('prefix/file.txt')
             ->once()
@@ -876,7 +874,8 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('name')
             ->once()
             ->andReturn('prefix/file.txt');
-        $storageObject->shouldReceive('info')
+
+        $bucket->shouldReceive('info')
             ->once()
             ->andReturn([
                 'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
@@ -884,7 +883,6 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
                 'contentType' => 'text/plain',
                 'size' => 5,
             ]);
-
         $bucket->shouldReceive('object')
             ->with('prefix/file.txt')
             ->once()

--- a/tests/GoogleStorageAdapterTests.php
+++ b/tests/GoogleStorageAdapterTests.php
@@ -43,6 +43,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -87,6 +88,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -131,6 +133,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -177,6 +180,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -360,6 +364,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -406,6 +411,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -456,6 +462,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -497,6 +504,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -550,6 +558,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -591,6 +600,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -678,6 +688,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $dir1->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'application/octet-stream',
                 'size' => 0,
@@ -690,6 +701,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $dir1file1->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -702,6 +714,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $dir2file1->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -726,6 +739,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -764,6 +778,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'application/octet-stream',
                 'size' => 0,
@@ -802,6 +817,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -832,6 +848,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,
@@ -862,6 +879,7 @@ class GoogleStorageAdapterTests extends \PHPUnit_Framework_TestCase
         $storageObject->shouldReceive('info')
             ->once()
             ->andReturn([
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => false]],
                 'updated' => '2016-09-26T14:44:42+00:00',
                 'contentType' => 'text/plain',
                 'size' => 5,


### PR DESCRIPTION
Based on this PR #114, but also updated the phpunit tests.

> Currently the code forces an ACL on the files, this doesn't work if the bucket has uniform access policies set. So this PR just checks whether the bucket has uniform access before setting the ACL.