### PR TITLE
Catch notfound exception on deleting non existing file

### DIFF
--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -273,7 +273,12 @@ class GoogleStorageAdapter extends AbstractAdapter
 
         // Execute deletion for each object.
         foreach ($filtered_objects as $object) {
-            $this->delete($object['path']);
+            try {
+                $this->delete($object['path']);
+            } catch (NotFoundException $e) {
+                // If the file does not exist, the Google Cloud PHP API throws an exception.
+                // This exception should be caught here and ignored.
+            }
         }
 
         return true;


### PR DESCRIPTION
### Issue

Projects using FlySystem can use League\Flysystem\AdapterInterface::deleteDir() to remove a directory from a filesystem.
This should return a boolean to indicate whether this succeeded. This GCP implementation does however throw an exception.

This Pull Request fixes the issue.

An example where this happens is in Shopware 6, described here https://github.com/shopware/platform/pull/2108

### Reproduction

* Use this project as described in README.md.
* Try to delete a directory from a GCP bucket that does not exist.
* See that instead of false being returned, a Google\Cloud\Core\Exception\NotFoundException is being thrown
* See that this can be an issue for downstream software relying on this repository.

### The fix

The fix is quite easy actually: catch the exception thrown by the Google Cloud PHP API, so this implementation of the AdapterInterface matches the expected behaviour.